### PR TITLE
fix: use http origin from CloudFront.

### DIFF
--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -7,7 +7,7 @@ resource "aws_cloudfront_distribution" "medialocal_distribution" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
@@ -63,7 +63,7 @@ resource "aws_cloudfront_distribution" "mediatest_distribution" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
@@ -119,7 +119,7 @@ resource "aws_cloudfront_distribution" "media_distribution" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
-      origin_protocol_policy = "https-only"
+      origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
   }


### PR DESCRIPTION
I incorrectly was attempting to use https between CloudFront and the origin (s3). S3 supports http only here.