### PR TITLE
fix: explicit jest expect import.

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,9 +1,11 @@
+/// <reference types="cypress" />
+
 import fs from "fs";
 import path from "path";
 
-const filePlugin = (on, config) => {
+const filePlugin = (on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) => {
   on("task", {
-    getMagicLink({ email }) {
+    getMagicLink({ email }: { email: string }) {
       // Convert email to safe filename
       const safeEmail = email.replace(/[@.]/g, "_");
       const tempDir = path.join(process.cwd(), ".cypress-temp");
@@ -23,7 +25,7 @@ const filePlugin = (on, config) => {
 
         return magicLink;
       } catch (error) {
-        throw new Error(`Error reading magic link for ${email}: ${error.message}`);
+        throw new Error(`Error reading magic link for ${email}: ${(error as Error).message}`);
       }
     },
 
@@ -51,7 +53,7 @@ const filePlugin = (on, config) => {
 const config = {
   e2e: {
     supportFile: "./cypress/support/e2e.ts",
-    setupNodeEvents(on, config) {
+    setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
       return filePlugin(on, config);
     },
     baseUrl: "http://localhost:3000",
@@ -60,7 +62,7 @@ const config = {
       TEST_EMAIL: process.env.CYPRESS_TEST_EMAIL || "test@ampdresume.com",
     },
     chromeWebSecurity: false,
-    specPattern: "./cypress/**/*.cy.js",
+    specPattern: "./cypress/**/*.cy.ts",
   },
 };
 

--- a/cypress/integration/account/experience.cy.ts
+++ b/cypress/integration/account/experience.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 /**
  * The Experience section is a complex section that allows users to add, edit, and delete companies
  * and positions within those companies. It also allows users to add projects to positions.

--- a/cypress/integration/account/import.cy.ts
+++ b/cypress/integration/account/import.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 import getParsedResumeAiResponse from "./data/getParsedResumeAiResponse.json";
 
 /**

--- a/cypress/integration/account/profile.cy.ts
+++ b/cypress/integration/account/profile.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 /**
  * The Profile section is a simple section that allows users to edit their personal information
  * including their name, slug, email, title, location, site title, and site description.

--- a/cypress/integration/account/skills.cy.ts
+++ b/cypress/integration/account/skills.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 /**
  * The Skills section is a simple section that allows users to add, edit, and delete skills.
  */

--- a/cypress/integration/navigation/pdfWorkerSpec.cy.ts
+++ b/cypress/integration/navigation/pdfWorkerSpec.cy.ts
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+
 import { expect } from "chai";
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,10 @@
         "@types/react": "^19.1.8",
         "@types/react-color": "^3.0.13",
         "@types/react-dom": "^19.1.6",
+        "@types/testing-library__jest-dom": "^5.14.9",
         "@typescript-eslint/parser": "^8.38.0",
         "babel-jest": "^30.0.1",
+        "chai": "^6.0.1",
         "cypress": "^14.5.0",
         "eslint": "^9",
         "eslint-config-next": "^15.3.4",
@@ -10034,6 +10036,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.9",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
+      "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jest": "*"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -12020,6 +12032,16 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/chai": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.0.1.tgz",
+      "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.6",
   "description": "Uniform standard for resume data.",
   "private": true,
-  "type": "module",
   "keywords": [
     "resume"
   ],
@@ -91,8 +90,10 @@
     "@types/react": "^19.1.8",
     "@types/react-color": "^3.0.13",
     "@types/react-dom": "^19.1.6",
+    "@types/testing-library__jest-dom": "^5.14.9",
     "@typescript-eslint/parser": "^8.38.0",
     "babel-jest": "^30.0.1",
+    "chai": "^6.0.1",
     "cypress": "^14.5.0",
     "eslint": "^9",
     "eslint-config-next": "^15.3.4",

--- a/src/app/about/privacy-policy/page.test.tsx
+++ b/src/app/about/privacy-policy/page.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import PrivacyPolicy from "./page";
+import { expect } from "@jest/globals";
 
 describe("PrivacyPolicy Page", () => {
   it("matches snapshot", () => {

--- a/src/app/about/terms-of-service/page.test.tsx
+++ b/src/app/about/terms-of-service/page.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import TermsOfService from "./page";
+import { expect } from "@jest/globals";
 
 describe("TermsOfService Page", () => {
   it("matches snapshot", () => {

--- a/src/app/components/Footer.test.tsx
+++ b/src/app/components/Footer.test.tsx
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { usePathname } from "next/navigation";
 import { render } from "@testing-library/react";
 import { Footer } from "./Footer";
+import { expect } from "@jest/globals";
 
 jest.mock("next/navigation");
 

--- a/src/app/components/Header.test.tsx
+++ b/src/app/components/Header.test.tsx
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom";
 import { useSession } from "next-auth/react";
-import React from "react";
 import { render } from "@testing-library/react";
 import { Header } from "./Header";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react");
 

--- a/src/app/components/Layout.test.tsx
+++ b/src/app/components/Layout.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
 import { useSession } from "next-auth/react";
-import React from "react";
 import { usePathname } from "next/navigation";
 import { render } from "@testing-library/react";
 import { Layout } from "./Layout";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react");
 jest.mock("next/navigation");

--- a/src/app/components/NavPrimary.test.tsx
+++ b/src/app/components/NavPrimary.test.tsx
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom";
 import { useSession } from "next-auth/react";
-import React from "react";
 import { render } from "@testing-library/react";
 import { NavPrimary } from "./NavPrimary";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   // Preserve other exports

--- a/src/app/components/ThemeAppearanceToggle.test.tsx
+++ b/src/app/components/ThemeAppearanceToggle.test.tsx
@@ -3,6 +3,7 @@ import { usePathname } from "next/navigation";
 import { fireEvent, render } from "@testing-library/react";
 import { ThemeAppearanceToggle } from "./ThemeAppearanceToggle";
 import { ThemeAppearanceContext } from "./ThemeContext";
+import { expect } from "@jest/globals";
 
 jest.mock("next/navigation");
 jest.mock("@/hooks/useIsDesktop", () => ({

--- a/src/app/components/ThemeContext.test.tsx
+++ b/src/app/components/ThemeContext.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom";
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { render } from "@testing-library/react";
 import { ThemeAppearanceContext, ThemeAppearanceProvider } from "./ThemeContext";
+import { expect } from "@jest/globals";
 
 function TestChild() {
   const { themeAppearance } = useContext(ThemeAppearanceContext);

--- a/src/app/demo/[themeName]/PDFView.test.tsx
+++ b/src/app/demo/[themeName]/PDFView.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import html2pdf from "html2pdf.js";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { PDFView } from "./PDFView";
+import { expect } from "@jest/globals";
 
 // Mock html2pdf
 jest.mock("html2pdf.js", () => ({

--- a/src/app/demo/[themeName]/ResumeView.test.tsx
+++ b/src/app/demo/[themeName]/ResumeView.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { ThemeAppearanceContext } from "@/app/components/ThemeContext";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { ResumeView } from "./ResumeView";
+import { expect } from "@jest/globals";
 
 // Mock the ThemeDefault component
 jest.mock("@/theme", () => ({

--- a/src/app/demo/[themeName]/page.test.tsx
+++ b/src/app/demo/[themeName]/page.test.tsx
@@ -3,6 +3,7 @@ import { titleSuffix } from "@/constants";
 import { themeDefinitions } from "@/theme";
 import { ThemeName } from "@/types";
 import Page, { generateMetadata } from "./page";
+import { expect } from "@jest/globals";
 
 // Mock the ResumeView component since we're only testing the page component
 jest.mock("./ResumeView", () => ({

--- a/src/app/demo/[themeName]/pdf/page.test.tsx
+++ b/src/app/demo/[themeName]/pdf/page.test.tsx
@@ -3,6 +3,7 @@ import { titleSuffix } from "@/constants";
 import { themeDefinitions } from "@/theme";
 import { ThemeName } from "@/types";
 import Page, { generateMetadata } from "./page";
+import { expect } from "@jest/globals";
 
 // Mock the PDFView component since we don't need to test its implementation
 jest.mock("../PDFView", () => ({

--- a/src/app/edit/components/DeleteWithConfirmation.test.tsx
+++ b/src/app/edit/components/DeleteWithConfirmation.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { DeleteWithConfirmation } from "./DeleteWithConfirmation";
+import { expect } from "@jest/globals";
 
 describe("DeleteWithConfirmation", () => {
   it("renders correctly with default props", () => {

--- a/src/app/edit/components/RichTextEditor/RichTextEditor.test.tsx
+++ b/src/app/edit/components/RichTextEditor/RichTextEditor.test.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { act, render } from "@testing-library/react";
 import { RichTextEditor } from "./RichTextEditor";
+import { expect } from "@jest/globals";
 
 describe("RichTextEditor", () => {
   it("renders without crashing", async () => {

--- a/src/app/edit/components/RichTextEditor/plugins/ToolbarPlugin.test.tsx
+++ b/src/app/edit/components/RichTextEditor/plugins/ToolbarPlugin.test.tsx
@@ -6,6 +6,7 @@ import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
 import { render } from "@testing-library/react";
 import { RICH_TEXT_OPTIONS } from "./constants";
 import { ToolbarPlugin } from "./ToolbarPlugin";
+import { expect } from "@jest/globals";
 
 const initialConfig = {
   namespace: "TestEditor",

--- a/src/app/edit/components/RichTextEditor/useKeyBindings.test.tsx
+++ b/src/app/edit/components/RichTextEditor/useKeyBindings.test.tsx
@@ -6,6 +6,7 @@ import { renderHook } from "@testing-library/react";
 import { createEditor, KEY_ENTER_COMMAND, LexicalEditor } from "lexical";
 import { RichTextAction } from "@/app/edit/components/RichTextEditor/plugins/constants";
 import { useKeyBindings } from "@/app/edit/components/RichTextEditor/useKeyBindings";
+import { expect } from "@jest/globals";
 
 describe("useKeyBindings", () => {
   let onAction: jest.Mock;

--- a/src/app/edit/components/SectionTitle.test.tsx
+++ b/src/app/edit/components/SectionTitle.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import { SectionTitle } from "./SectionTitle";
+import { expect } from "@jest/globals";
 
 describe("SectionTitle", () => {
   it("renders correctly with the provided title", () => {

--- a/src/app/edit/components/UpdateWithConfirmation.test.tsx
+++ b/src/app/edit/components/UpdateWithConfirmation.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { UpdateWithConfirmation } from "./UpdateWithConfirmation";
+import { expect } from "@jest/globals";
 
 describe("UpdateWithConfirmation", () => {
   it("renders correctly with default props", async () => {

--- a/src/app/edit/education/EditEducation.test.tsx
+++ b/src/app/edit/education/EditEducation.test.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { render, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
 import { EditEducation } from "./EditEducation";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/education/EducationForm.test.tsx
+++ b/src/app/edit/education/EducationForm.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { EducationForm } from "./EducationForm";
+import { expect } from "@jest/globals";
 
 describe("EducationForm", () => {
   const mockEducation = {

--- a/src/app/edit/education/EducationItem.test.tsx
+++ b/src/app/edit/education/EducationItem.test.tsx
@@ -1,12 +1,12 @@
 import "@testing-library/jest-dom";
 import { useSession } from "next-auth/react";
-import React from "react";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateEducation } from "@/graphql/updateEducation";
 import { EducationItem } from "./EducationItem";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/import/ExtractedDataContext.test.tsx
+++ b/src/app/edit/import/ExtractedDataContext.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { ExtractedDataProvider, useExtractedData } from "./ExtractedDataContext";
 import { ParsedResumeData } from "./types";
+import { expect } from "@jest/globals";
 
 // Test component that uses the context
 const TestComponent = () => {

--- a/src/app/edit/import/education/ExtractedEducation.test.tsx
+++ b/src/app/edit/import/education/ExtractedEducation.test.tsx
@@ -4,6 +4,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ExtractedDataProvider } from "../ExtractedDataContext";
 import { ExtractedEducation } from "./ExtractedEducation";
+import { expect } from "@jest/globals";
 
 // Mock the ExtractedDataContext
 jest.mock("../ExtractedDataContext", () => ({

--- a/src/app/edit/profile/components/AccountForm.test.tsx
+++ b/src/app/edit/profile/components/AccountForm.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { useIsDesktop } from "@/hooks/useIsDesktop";
 import { AccountForm } from "./AccountForm";
+import { expect } from "@jest/globals";
 
 jest.mock("@/hooks/useIsDesktop", () => ({
   useIsDesktop: jest.fn(),

--- a/src/app/edit/profile/components/SocialsForm.test.tsx
+++ b/src/app/edit/profile/components/SocialsForm.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { SocialsForm } from "./SocialsForm";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/profile/components/sections.test.tsx
+++ b/src/app/edit/profile/components/sections.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import { FieldDescription, FieldTitle, GridSection, InputSection, SectionTitle } from "./sections";
+import { expect } from "@jest/globals";
 
 describe("sections components", () => {
   it("renders InputSection correctly", () => {

--- a/src/app/edit/profile/page.test.tsx
+++ b/src/app/edit/profile/page.test.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import Page from "./page";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/skills/EditSkills.test.tsx
+++ b/src/app/edit/skills/EditSkills.test.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { render, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
 import { EditSkills } from "./EditSkills";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/skills/EditSkillsSearch.test.tsx
+++ b/src/app/edit/skills/EditSkillsSearch.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { EditSkillsSearch } from "./EditSkillsSearch";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/skills/SkillItem.test.tsx
+++ b/src/app/edit/skills/SkillItem.test.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { SkillItem } from "./SkillItem";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/skills/SkillItemEdit.test.tsx
+++ b/src/app/edit/skills/SkillItemEdit.test.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteSkillForUser } from "@/graphql/deleteSkillForUser";
 import { updateSkillForUser } from "@/graphql/updateSkillForUser";
 import { SkillItemEdit } from "./SkillItemEdit";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(),

--- a/src/app/edit/skills/SkillsExperience.test.tsx
+++ b/src/app/edit/skills/SkillsExperience.test.tsx
@@ -3,6 +3,7 @@ import { SkillForUser } from "@/types";
 import { groupSkillsForUserByYearExperience } from "@/util/structure";
 import { render } from "@testing-library/react";
 import { SkillsExperience } from "./SkillsExperience";
+import { expect } from "@jest/globals";
 
 jest.mock("@/util/structure", () => ({
   groupSkillsForUserByYearExperience: jest.fn(),

--- a/src/app/edit/skills/page.test.tsx
+++ b/src/app/edit/skills/page.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import Page from "./page";
+import { expect } from "@jest/globals";
 
 jest.mock("./EditSkills", () => ({
   EditSkills: () => <div>EditSkills Component</div>,

--- a/src/app/login/SignIn.test.tsx
+++ b/src/app/login/SignIn.test.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
 import { signIn } from "next-auth/react";
-import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import * as Sentry from "@sentry/react";
 import { SignIn } from "./SignIn";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   signIn: jest.fn(),

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import SignInPage from "./page";
+import { expect } from "@jest/globals";
 
 jest.mock("./SignIn", () => ({
   SignIn: jest.fn(() => <div>Mocked SignIn Component</div>),

--- a/src/app/login/verify/page.test.tsx
+++ b/src/app/login/verify/page.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import Verify from "./page";
+import { expect } from "@jest/globals";
 
 describe("Verify Page", () => {
   it("renders correctly", () => {

--- a/src/app/logout/page.test.tsx
+++ b/src/app/logout/page.test.tsx
@@ -1,8 +1,8 @@
 import "@testing-library/jest-dom";
 import { signOut } from "next-auth/react";
-import React from "react";
 import { render } from "@testing-library/react";
 import LogoutPage from "./page";
+import { expect } from "@jest/globals";
 
 jest.mock("next-auth/react", () => ({
   signOut: jest.fn(),

--- a/src/components/CloseButton.test.tsx
+++ b/src/components/CloseButton.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { CloseButton } from "./CloseButton";
+import { expect } from "@jest/globals";
 
 describe("CloseButton", () => {
   it("renders correctly", () => {

--- a/src/components/CustomDialogTitle.test.tsx
+++ b/src/components/CustomDialogTitle.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { fireEvent, render } from "@testing-library/react";
 import { CustomDialogTitle } from "./CustomDialogTitle";
+import { expect } from "@jest/globals";
 
 describe("CustomDialogTitle", () => {
   it("renders correctly with children", () => {

--- a/src/components/IconSelector.test.tsx
+++ b/src/components/IconSelector.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { IconSelector } from "./IconSelector";
+import { expect } from "@jest/globals";
 
 global.fetch = jest.fn();
 

--- a/src/components/LoadingOverlay.test.tsx
+++ b/src/components/LoadingOverlay.test.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
+import { expect } from "@jest/globals";
 
 describe("LoadingOverlay", () => {
   test("renders with default props", () => {

--- a/src/components/MessageDialog.test.tsx
+++ b/src/components/MessageDialog.test.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MessageDialog } from "@/components/MessageDialog";
+import { expect } from "@jest/globals";
 
 describe("MessageDialog", () => {
   it("renders with default props", async () => {

--- a/src/components/MuiLink.test.tsx
+++ b/src/components/MuiLink.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { MuiLink } from "@/components/MuiLink";
+import { expect } from "@jest/globals";
 
 describe("MuiLink", () => {
   it("renders correctly with given props", () => {

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Tooltip } from "@/components/Tooltip";
+import { expect } from "@jest/globals";
 
 describe("Tooltip component", () => {
   it("renders the tooltip message on hover", async () => {

--- a/src/components/tooltips/tooltips.test.tsx
+++ b/src/components/tooltips/tooltips.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
-import React from "react";
 import { render } from "@testing-library/react";
 import { TooltipTotalYears } from "./";
+import { expect } from "@jest/globals";
 
 describe("TooltipTotalYears", () => {
   it("matches snapshot", () => {

--- a/src/graphql/server/resolvers/mutations/addSkillForUser.test.ts
+++ b/src/graphql/server/resolvers/mutations/addSkillForUser.test.ts
@@ -1,6 +1,7 @@
 import { verifySessionOwnership } from "@/graphql/server/util";
 import { prisma } from "@/lib/prisma";
 import { addSkillForUser } from "./addSkillForUser";
+import { expect } from "@jest/globals";
 
 // Mock dependencies
 jest.mock("next-auth", () => ({

--- a/src/graphql/server/resolvers/mutations/deleteUser.test.ts
+++ b/src/graphql/server/resolvers/mutations/deleteUser.test.ts
@@ -2,6 +2,7 @@ import type { User } from "@prisma/client";
 import { verifySessionOwnership } from "@/graphql/server/util";
 import { prisma } from "@/lib/prisma";
 import { deleteUser } from "./deleteUser";
+import { expect } from "@jest/globals";
 
 // Mock dependencies
 jest.mock("@/lib/prisma", () => ({

--- a/src/graphql/server/resolvers/mutations/updateSkillForUser.test.ts
+++ b/src/graphql/server/resolvers/mutations/updateSkillForUser.test.ts
@@ -1,6 +1,7 @@
 import { verifySessionOwnership } from "@/graphql/server/util";
 import { prisma } from "@/lib/prisma";
 import { updateSkillForUser } from "./updateSkillForUser";
+import { expect } from "@jest/globals";
 
 jest.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/hooks/useIsDesktop.test.tsx
+++ b/src/hooks/useIsDesktop.test.tsx
@@ -1,6 +1,7 @@
 import { createTheme, ThemeProvider } from "@mui/material";
 import { renderHook } from "@testing-library/react";
 import { useIsDesktop } from "@/hooks/useIsDesktop";
+import { expect } from "@jest/globals";
 
 const theme = createTheme({
   breakpoints: {

--- a/src/hooks/useIsLoggedIn.test.ts
+++ b/src/hooks/useIsLoggedIn.test.ts
@@ -1,6 +1,7 @@
 import { useSession } from "next-auth/react";
 import { renderHook } from "@testing-library/react";
 import { useIsLoggedIn } from "@/hooks/useIsLoggedIn";
+import { expect } from "@jest/globals";
 
 // Mock the useSession hook
 jest.mock("next-auth/react");

--- a/src/hooks/useIsResumePage.test.ts
+++ b/src/hooks/useIsResumePage.test.ts
@@ -1,6 +1,7 @@
 import { usePathname } from "next/navigation";
 import { renderHook } from "@testing-library/react";
 import { useIsResumePage } from "@/hooks/useIsResumePage";
+import { expect } from "@jest/globals";
 
 // Mock the usePathname hook from next/navigation
 jest.mock("next/navigation", () => ({

--- a/src/lib/apolloClient.test.ts
+++ b/src/lib/apolloClient.test.ts
@@ -1,5 +1,6 @@
 import { ApolloClient } from "@apollo/client";
 import { getApolloClient } from "@/lib/apolloClient";
+import { expect } from "@jest/globals";
 
 describe("getApolloClient", () => {
   beforeAll(() => {

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth/next";
 import nodemailer from "nodemailer";
 import { authOptions, sendVerificationRequest } from "@/lib/auth";
+import { expect } from "@jest/globals";
 
 // Mock dependencies
 jest.mock("@prisma/client", () => ({

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { parseDateString, validateAndConvertDate } from "./dateUtils";
+import { expect } from "@jest/globals";
 
 describe("dateUtils", () => {
   describe("validateAndConvertDate", () => {

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { formatLongDate } from "@/lib/format";
+import { expect } from "@jest/globals";
 
 describe("formatDate", () => {
   it("should return an empty string for null or undefined timestamp", () => {

--- a/src/lib/s3.test.ts
+++ b/src/lib/s3.test.ts
@@ -6,6 +6,7 @@ import {
   S3Client,
 } from "@aws-sdk/client-s3";
 import { flagForDeletion, objectExists, revertFlagForDeletion, uploadObject } from "./s3";
+import { expect } from "@jest/globals";
 
 jest.mock("@aws-sdk/client-s3", () => {
   return {

--- a/src/lib/secureHtmlParser.test.ts
+++ b/src/lib/secureHtmlParser.test.ts
@@ -4,6 +4,7 @@ import {
   ALLOWED_TAGS,
   ALLOWED_ATTRIBUTES,
 } from "./secureHtmlParser";
+import { expect } from "@jest/globals";
 
 describe("secureHtmlParser", () => {
   describe("secureHtmlParserOptions", () => {

--- a/src/theme/components/Education/Education.test.tsx
+++ b/src/theme/components/Education/Education.test.tsx
@@ -3,6 +3,7 @@ import { formatLongDate } from "@/lib/format";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import type { Education as EducationType } from "@/types";
 import { Education } from "./Education";
+import { expect } from "@jest/globals";
 
 describe("Education Component", () => {
   const sampleEducation = themeDefaultSampleData.data.resume.education;

--- a/src/theme/components/ResumeTitle/ResumeTitle.test.tsx
+++ b/src/theme/components/ResumeTitle/ResumeTitle.test.tsx
@@ -1,6 +1,7 @@
 import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen } from "@testing-library/react";
 import { ResumeTitle } from "./ResumeTitle";
+import { expect } from "@jest/globals";
 
 const theme = createTheme();
 

--- a/src/theme/components/RichTextBlock.test.tsx
+++ b/src/theme/components/RichTextBlock.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { RichTextBlock } from "./RichTextBlock";
+import { expect } from "@jest/globals";
 
 describe("RichTextBlock", () => {
   it("should render null when content is null", () => {

--- a/src/theme/components/Skills/SkillItem.test.tsx
+++ b/src/theme/components/Skills/SkillItem.test.tsx
@@ -4,6 +4,7 @@ import { SkillForProject, SkillForUser } from "@/types";
 import { SkillItem } from "./SkillItem";
 import { SkillsContext } from "./Skills";
 import { reactSkill } from "./testUtils";
+import { expect } from "@jest/globals";
 
 // Mock the Iconify Icon component
 jest.mock("@iconify/react", () => ({

--- a/src/theme/components/Skills/SkillItemView.test.tsx
+++ b/src/theme/components/Skills/SkillItemView.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { SkillForUser } from "@/types";
 import { SkillItemView } from "./SkillItemView";
 import { reactSkill } from "./testUtils";
+import { expect } from "@jest/globals";
 
 const theme = createTheme();
 

--- a/src/theme/components/Skills/Skills.test.tsx
+++ b/src/theme/components/Skills/Skills.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { SkillForUser } from "@/types";
 import { Skills } from "./Skills";
 import { javascriptSkill, reactSkill, sampleSkills } from "./testUtils";
+import { expect } from "@jest/globals";
 
 describe("Skills", () => {
   beforeAll(() => {

--- a/src/theme/components/Skills/SkillsCloud.test.tsx
+++ b/src/theme/components/Skills/SkillsCloud.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { SkillForUser } from "@/types";
 import { SkillsCloud } from "./SkillsCloud";
 import { createInvalidSkill, javascriptSkill, reactSkill } from "./testUtils";
+import { expect } from "@jest/globals";
 
 describe("SkillsCloud", () => {
   it("renders all skills in a cloud layout", () => {

--- a/src/theme/components/Skills/SkillsExperience.test.tsx
+++ b/src/theme/components/Skills/SkillsExperience.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { SkillForUser } from "@/types";
 import { SkillsExperience } from "./SkillsExperience";
 import { javascriptSkill, reactSkill } from "./testUtils";
+import { expect } from "@jest/globals";
 
 describe("SkillsExperience", () => {
   beforeAll(() => {

--- a/src/theme/davids/components/Certifications.test.tsx
+++ b/src/theme/davids/components/Certifications.test.tsx
@@ -2,6 +2,7 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen } from "@testing-library/react";
 import { Certification } from "@/types";
 import { CertificationsSection } from "./Certifications";
+import { expect } from "@jest/globals";
 
 // TODO: Use the sample data for this after it's added to the sample data file.
 const mockCertifications: Certification[] = [

--- a/src/theme/davids/components/FeaturedProjects.test.tsx
+++ b/src/theme/davids/components/FeaturedProjects.test.tsx
@@ -2,6 +2,7 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen } from "@testing-library/react";
 import { FeaturedProject } from "@/types";
 import { FeaturedProjects } from "./FeaturedProjects";
+import { expect } from "@jest/globals";
 
 // TODO: Use the sample data for this after it's added to the sample data file.
 const sampleProjects: FeaturedProject[] = [

--- a/src/theme/davids/components/Summary.test.tsx
+++ b/src/theme/davids/components/Summary.test.tsx
@@ -3,6 +3,7 @@ import { createTheme, ThemeProvider } from "@mui/material";
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Summary } from "./Summary";
+import { expect } from "@jest/globals";
 
 // Helper function to render with theme
 const renderWithTheme = (component: React.ReactElement, mode: "light" | "dark" = "light") => {

--- a/src/theme/default/ThemeDefault.test.tsx
+++ b/src/theme/default/ThemeDefault.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { ThemeAppearance } from "@/types";
 import { themeDefaultSampleData } from "../sampleData";
 import { ThemeDefault } from "./ThemeDefault";
+import { expect } from "@jest/globals";
 
 describe("ThemeDefault", () => {
   const mockProps = {

--- a/src/theme/default/ThemeDefaultPDF.test.tsx
+++ b/src/theme/default/ThemeDefaultPDF.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "../sampleData";
 import { ThemeDefaultPDF } from "./ThemeDefaultPDF";
+import { expect } from "@jest/globals";
 
 describe("ThemeDefaultPDF", () => {
   const mockData = themeDefaultSampleData.data.resume;

--- a/src/theme/default/components/ResumeHeading.test.tsx
+++ b/src/theme/default/components/ResumeHeading.test.tsx
@@ -1,9 +1,9 @@
-import "@testing-library/jest-dom";
 import { usePathname } from "next/navigation";
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { generateSocialUrl, getSocialMediaPlatformByPlatformName } from "@/util/social";
 import { ResumeHeading } from "./ResumeHeading";
+import { expect } from "@jest/globals";
 
 // Mock the usePathname hook
 jest.mock("next/navigation", () => ({

--- a/src/theme/default/components/WorkExperience/PositionSingle.test.tsx
+++ b/src/theme/default/components/WorkExperience/PositionSingle.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { PositionSingle } from "./PositionSingle";
+import { expect } from "@jest/globals";
 
 // Mock the useIsDesktop hook
 jest.mock("@/hooks/useIsDesktop", () => ({

--- a/src/theme/default/components/WorkExperience/PositionsList.test.tsx
+++ b/src/theme/default/components/WorkExperience/PositionsList.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { PositionsList } from "./PositionsList";
+import { expect } from "@jest/globals";
 
 describe("PositionsList", () => {
   const sampleCompany = themeDefaultSampleData.data.resume.companies[0];

--- a/src/theme/default/components/WorkExperience/ProjectAccordion.test.tsx
+++ b/src/theme/default/components/WorkExperience/ProjectAccordion.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { Project } from "@/types";
 import sampleData from "../../../sampleData.json";
 import { ProjectAccordion } from "./ProjectAccordion";
+import { expect } from "@jest/globals";
 
 const theme = createTheme();
 

--- a/src/theme/default/components/WorkExperience/ProjectItem.test.tsx
+++ b/src/theme/default/components/WorkExperience/ProjectItem.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { Project } from "@/types";
 import sampleData from "../../../sampleData.json";
 import { ProjectItem } from "./ProjectItem";
+import { expect } from "@jest/globals";
 
 const theme = createTheme();
 

--- a/src/theme/default/components/WorkExperience/Projects.test.tsx
+++ b/src/theme/default/components/WorkExperience/Projects.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Project } from "@/types";
 import { Projects } from "./Projects";
+import { expect } from "@jest/globals";
 
 // Mock the child components
 jest.mock("./ProjectAccordion", () => ({

--- a/src/theme/default/components/WorkExperience/WorkExperience.test.tsx
+++ b/src/theme/default/components/WorkExperience/WorkExperience.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Company } from "@/types";
 import { WorkExperience } from "./WorkExperience";
+import { expect } from "@jest/globals";
 
 // Mock the child components
 jest.mock("./PositionsList", () => ({

--- a/src/theme/default/components/pdf/Education.test.tsx
+++ b/src/theme/default/components/pdf/Education.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { formatLongDate } from "@/lib/format";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Education } from "./Education";
+import { expect } from "@jest/globals";
 
 describe("Education", () => {
   const sampleEducation = themeDefaultSampleData.data.resume.education;

--- a/src/theme/default/components/pdf/Header.test.tsx
+++ b/src/theme/default/components/pdf/Header.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Header } from "./Header";
+import { expect } from "@jest/globals";
 
 describe("Header", () => {
   const sampleUser = themeDefaultSampleData.data.resume.user;

--- a/src/theme/default/components/pdf/Skills.test.tsx
+++ b/src/theme/default/components/pdf/Skills.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { Skills } from "./Skills";
+import { expect } from "@jest/globals";
 
 describe("Skills", () => {
   const sampleSkills = themeDefaultSampleData.data.resume.skillsForUser;

--- a/src/theme/default/components/pdf/WorkExperience.test.tsx
+++ b/src/theme/default/components/pdf/WorkExperience.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { themeDefaultSampleData } from "@/theme/sampleData";
 import { WorkExperience } from "./WorkExperience";
+import { expect } from "@jest/globals";
 
 describe("WorkExperience", () => {
   const companies = themeDefaultSampleData.data.resume.companies;

--- a/src/types/html2pdf.d.ts
+++ b/src/types/html2pdf.d.ts
@@ -1,0 +1,19 @@
+declare module "html2pdf.js" {
+  interface Html2PdfOptions {
+    margin?: number | number[];
+    filename?: string;
+    image?: { type: string; quality: number };
+    html2canvas?: { scale: number };
+    jsPDF?: { unit: string; format: string; orientation: string };
+    pagebreak?: { mode: string[] };
+  }
+
+  interface Html2PdfInstance {
+    from(element: HTMLElement): Html2PdfInstance;
+    set(options: Html2PdfOptions): Html2PdfInstance;
+    outputPdf(type: string): Promise<string>;
+  }
+
+  function html2pdf(): Html2PdfInstance;
+  export = html2pdf;
+}

--- a/src/util/email.test.ts
+++ b/src/util/email.test.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { findUserByNormalizedEmail, normalizeEmail } from "@/util/email";
+import { expect, describe, it } from "@jest/globals";
 
 jest.mock("@/lib/prisma", () => ({
   prisma: {

--- a/src/util/social.test.ts
+++ b/src/util/social.test.ts
@@ -1,5 +1,6 @@
 import { SOCIAL_MEDIA_PLATFORMS } from "@/constants";
 import { getSocialMediaPlatformByPlatformName } from "./social";
+import { expect, describe, it } from "@jest/globals";
 
 describe("getSocialMediaPlatformByPlatformName", () => {
   it("returns the correct platform object for known platform", () => {

--- a/src/util/url.test.ts
+++ b/src/util/url.test.ts
@@ -1,4 +1,5 @@
 import { getBaseUrl } from "@/util/url";
+import { expect, describe, it } from "@jest/globals";
 
 describe("getBaseUrl", () => {
   const originalEnv = process.env;

--- a/src/util/userAsset.test.ts
+++ b/src/util/userAsset.test.ts
@@ -1,4 +1,5 @@
 import { deleteUserAsset, manageUserAsset, undeleteUserAsset, uploadUserAsset } from "./userAsset";
+import { expect, describe, it } from "@jest/globals";
 
 global.fetch = jest.fn();
 

--- a/src/util/userData.test.ts
+++ b/src/util/userData.test.ts
@@ -1,3 +1,4 @@
+import { expect, describe, it } from "@jest/globals";
 import { removeHiddenFields } from "./userData";
 
 describe("removeHiddenFields", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["jest"],
+    "types": ["jest", "@testing-library/jest-dom", "cypress"],
     "target": "esnext"
   },
   "include": ["**/*.ts", "**/*.tsx", "next-env.d.ts", ".next/types/**/*.ts"],


### PR DESCRIPTION
Thank you for submitting a PR! Please review & check the boxes below:

- [x] I have filled in the "Description" section below.
- [x] I have provided manual testing steps and screenshots (if applicable).
- [x] My code is covered by automated tests.

## Description

Update: the linter was complaining about Jest types after I converted Cypress to TypeScript. In order to fix the Jest types, I needed to explicitly import `expect` from the `@jest/globals` package at the top of Jest test files.

## Steps to Test

Check out PR, `npm i` to install deps, then `npm run check` to run all checks locally.